### PR TITLE
Add bvh for generate_sdf method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
+name = "bvh"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130070ae145ee1deee52b77d4bbf7a0345ee1771ee363211807ddaaf64652f0d"
+dependencies = [
+ "approx 0.5.1",
+ "log",
+ "nalgebra",
+ "num",
+ "rand",
+ "rayon",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2191,7 @@ dependencies = [
 name = "mesh_to_sdf"
 version = "0.2.1"
 dependencies = [
+ "bvh",
  "cgmath",
  "criterion",
  "easy-gltf",
@@ -2304,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.33.0"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4b5f057b303842cf3262c27e465f4c303572e7f6b0648f60e16248ac3397f4"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
 dependencies = [
  "approx 0.5.1",
  "matrixmultiply",
@@ -2421,6 +2436,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2487,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3298,9 +3338,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx 0.5.1",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ missing_docs = "warn"
 unexpected_cfgs = "warn"
 
 [workspace.lints.clippy]
-all = "warn"
+all = { level = "warn", priority = -1 }
 await_holding_lock = "warn"
 char_lit_as_u8 = "warn"
 checked_conversions = "warn"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This crate provides two entry points:
 - [`generate_grid_sdf`]: computes the signed distance field for the mesh defined by `vertices` and `indices` on a [Grid].
 
 ```rust
-use mesh_to_sdf::{generate_sdf, generate_grid_sdf, SignMethod, Topology, Grid};
+use mesh_to_sdf::{generate_sdf, generate_grid_sdf, SignMethod, AccelerationMethod, Topology, Grid};
 // vertices are [f32; 3], but can be cgmath::Vector3<f32>, glam::Vec3, etc.
 let vertices: Vec<[f32; 3]> = vec![[0.5, 1.5, 0.5], [1., 2., 3.], [1., 3., 7.]];
 let indices: Vec<u32> = vec![0, 1, 2];
@@ -47,8 +47,9 @@ let sdf: Vec<f32> = generate_sdf(
     &vertices,
     Topology::TriangleList(Some(&indices)), // TriangleList as opposed to TriangleStrip
     &query_points,
-    SignMethod::Raycast, // How the sign is computed.
-);                       // Raycast is robust but requires the mesh to be watertight.
+    AccelerationMethod::Bvh,    // Use bvh to accelerate queries.
+    SignMethod::Raycast,        // How the sign is computed.
+);                              // Raycast is robust but requires the mesh to be watertight.
 
 for point in query_points.iter().zip(sdf.iter()) {
     // distance is positive outside the mesh and negative inside.
@@ -157,7 +158,6 @@ This project is still in its early stages. Here is a list of things that are pla
 - [x] [lib] Implement `Point` for common libraries (`cgmath`, `nalgebra`, `mint`, ...)
 - [x] [lib] Optimize `mesh_to_sdf` with a bvh
 - [ ] [lib] Optimize `mesh_to_sdf` by computing on the gpu
-- [ ] [lib] Load/Save vf files
 - [x] [lib] Serialize/Deserialize with `serde` and save/load to file
 - [x] [lib] General optimizations
 - [x] [lib] Tests/Benchmarks/Examples

--- a/mesh_to_sdf/CHANGELOG.md
+++ b/mesh_to_sdf/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- `generate_sdf` takes an additional `AccelerationMethod` parameter, that can be either `AccelerationMethod::Bvh` (default) or `AccelerationMethod::None`.
+    `Bvh` is recommended unless you're really tight on memory or your query is very small (couple hundreds of queries and triangles).
+    For example, a query of 15k points with 100k triangles is 10 times faster with a bvh, and twice faster for 500 queries and 10k triangles.
+    `Bvh` is also optimised for the `SignMethod::Raycast` sign method. https://github.com/Azkellas/mesh_to_sdf/pull/75
+
+### Fixed
+
+- Fix https://github.com/Azkellas/mesh_to_sdf/issues/25 where `generate_grid_sdf` might panic if the grid does not contain the mesh.
+
+
 ## [0.2.1] - 2024-02-18
 
 ### Changed

--- a/mesh_to_sdf/CHANGELOG.md
+++ b/mesh_to_sdf/CHANGELOG.md
@@ -8,10 +8,12 @@
     `Bvh` is recommended unless you're really tight on memory or your query is very small (couple hundreds of queries and triangles).
     For example, a query of 15k points with 100k triangles is 10 times faster with a bvh, and twice faster for 500 queries and 10k triangles.
     `Bvh` is also optimised for the `SignMethod::Raycast` sign method. https://github.com/Azkellas/mesh_to_sdf/pull/75
+- Both generic and grid based sdfs can now be (de-)serialized. Use `SerializeGrid` and `DeserializeGrid`, or the helpers `save_to_file` and `read_from_file`.
 
 ### Fixed
 
 - Fix https://github.com/Azkellas/mesh_to_sdf/issues/25 where `generate_grid_sdf` might panic if the grid does not contain the mesh.
+- Make grid based generation ~2x faster by improving heap generation.
 
 ### Removed
 

--- a/mesh_to_sdf/CHANGELOG.md
+++ b/mesh_to_sdf/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Fix https://github.com/Azkellas/mesh_to_sdf/issues/25 where `generate_grid_sdf` might panic if the grid does not contain the mesh.
 
+### Removed
+
+- nalgebra is no longer optional as it is required by bvh. The feature was removed as it will always be available.
+
 
 ## [0.2.1] - 2024-02-18
 

--- a/mesh_to_sdf/Cargo.toml
+++ b/mesh_to_sdf/Cargo.toml
@@ -25,11 +25,12 @@ itertools = "0.13.0"
 log = "0.4.22"
 ordered-float = "4.2.2"
 rayon = "1.10.0"
+bvh = "0.9.0"
 
 glam = { version = "0.29.0", optional = true }
 mint = { version = "0.5.9", optional = true }
-nalgebra = { version = "0.33.0", optional = true }
 cgmath = { version = "0.18.0", optional = true }
+nalgebra = "0.33.0"                              # required for bvh.
 
 serde = { version = "1.0.209", features = ["derive"], optional = true }
 rmp-serde = { version = "1.3.0", optional = true }
@@ -37,7 +38,6 @@ rmp-serde = { version = "1.3.0", optional = true }
 [features]
 glam = ["dep:glam"]
 mint = ["dep:mint"]
-nalgebra = ["dep:nalgebra"]
 cgmath = ["dep:cgmath"]
 serde = [
     "dep:serde",

--- a/mesh_to_sdf/Cargo.toml
+++ b/mesh_to_sdf/Cargo.toml
@@ -44,13 +44,13 @@ serde = [
     "dep:rmp-serde",
     "glam?/serde",
     "mint?/serde",
-    "nalgebra?/serde-serialize",
+    "nalgebra/serde-serialize",
     "cgmath?/serde",
 ]
 
 [dev-dependencies]
-easy-gltf = "1.1.2"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+easy-gltf = "1.1.2"
 proptest = "1.5.0"
 env_logger = "0.11.5"
 tempfile = "3.12.0"

--- a/mesh_to_sdf/Cargo.toml
+++ b/mesh_to_sdf/Cargo.toml
@@ -30,7 +30,7 @@ bvh = "0.9.0"
 glam = { version = "0.29.0", optional = true }
 mint = { version = "0.5.9", optional = true }
 cgmath = { version = "0.18.0", optional = true }
-nalgebra = "0.33.0"                              # required for bvh.
+nalgebra = "0.32.6"                              # required for bvh.
 
 serde = { version = "1.0.209", features = ["derive"], optional = true }
 rmp-serde = { version = "1.3.0", optional = true }

--- a/mesh_to_sdf/README.md
+++ b/mesh_to_sdf/README.md
@@ -10,7 +10,7 @@ This crate provides two entry points:
 - [`generate_grid_sdf`]: computes the signed distance field for the mesh defined by `vertices` and `indices` on a [Grid].
 
 ```rust
-use mesh_to_sdf::{generate_sdf, generate_grid_sdf, SignMethod, Topology, Grid};
+use mesh_to_sdf::{generate_sdf, generate_grid_sdf, SignMethod, AccelerationMethod, Topology, Grid};
 // vertices are [f32; 3], but can be cgmath::Vector3<f32>, glam::Vec3, etc.
 let vertices: Vec<[f32; 3]> = vec![[0.5, 1.5, 0.5], [1., 2., 3.], [1., 3., 7.]];
 let indices: Vec<u32> = vec![0, 1, 2];
@@ -23,6 +23,7 @@ let sdf: Vec<f32> = generate_sdf(
     &vertices,
     Topology::TriangleList(Some(&indices)), // TriangleList as opposed to TriangleStrip
     &query_points,
+    AccelerationMethod::Bvh, // Use bvh to accelerate queries.
     SignMethod::Raycast, // How the sign is computed.
 );                       // Raycast is robust but requires the mesh to be watertight.
 

--- a/mesh_to_sdf/benches/generate_sdf.rs
+++ b/mesh_to_sdf/benches/generate_sdf.rs
@@ -59,6 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&vertices),
                 black_box(mesh_to_sdf::Topology::TriangleList(Some(indices))),
                 black_box(&query_points),
+                black_box(mesh_to_sdf::AccelerationMethod::None),
                 black_box(mesh_to_sdf::SignMethod::Normal),
             );
         });
@@ -70,7 +71,20 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&vertices),
                 black_box(mesh_to_sdf::Topology::TriangleList(Some(indices))),
                 black_box(&query_points),
+                black_box(mesh_to_sdf::AccelerationMethod::None),
                 black_box(mesh_to_sdf::SignMethod::Raycast),
+            );
+        });
+    });
+
+    c.bench_function("generate_sdf_bvh", |b| {
+        b.iter(|| {
+            mesh_to_sdf::generate_sdf(
+                black_box(&vertices),
+                black_box(mesh_to_sdf::Topology::TriangleList(Some(indices))),
+                black_box(&query_points),
+                black_box(mesh_to_sdf::AccelerationMethod::Bvh),
+                black_box(mesh_to_sdf::SignMethod::Normal),
             );
         });
     });

--- a/mesh_to_sdf/examples/demo.rs
+++ b/mesh_to_sdf/examples/demo.rs
@@ -29,6 +29,7 @@ fn main() {
         &vertices,
         mesh_to_sdf::Topology::TriangleList(Some(indices)),
         &query_points,
+        mesh_to_sdf::AccelerationMethod::Bvh,
         mesh_to_sdf::SignMethod::Raycast,
     );
 

--- a/mesh_to_sdf/src/bvh_ext.rs
+++ b/mesh_to_sdf/src/bvh_ext.rs
@@ -87,8 +87,8 @@ impl<V: Point> BvhDistance<V> for Bvh<f32, 3> {
 
         indices
             .into_iter()
-            .filter(|(_, node_min, _)| *node_min <= best_max_distance)
-            .map(|(i, _, _)| i)
+            .filter(|(_, node_min)| *node_min <= best_max_distance)
+            .map(|(i, _)| i)
             .collect()
     }
 }
@@ -100,7 +100,7 @@ pub trait BvhTraverseDistance<V: Point> {
         nodes: &[Self],
         node_index: usize,
         origin: &V,
-        indices: &mut Vec<(usize, f32, f32)>,
+        indices: &mut Vec<(usize, f32)>,
         best_min_distance: &mut f32,
         best_max_distance: &mut f32,
     ) where
@@ -115,7 +115,7 @@ impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
         nodes: &[Self],
         node_index: usize,
         origin: &V,
-        indices: &mut Vec<(usize, f32, f32)>,
+        indices: &mut Vec<(usize, f32)>,
         best_min_distance: &mut f32,
         best_max_distance: &mut f32,
     ) {
@@ -164,7 +164,7 @@ impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
             } => {
                 // Try to compute bounding box via parent node to update best_min/max_distances
                 let parent_node = &nodes[parent_index];
-                let (min_dist, max_dist) = if let BvhNode::Node {
+                let min_dist = if let BvhNode::Node {
                     ref child_l_aabb,
                     child_l_index,
                     ref child_r_aabb,
@@ -188,14 +188,14 @@ impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
                     *best_min_distance = best_min_distance.min(min_dist);
                     *best_max_distance = best_max_distance.min(max_dist);
 
-                    (min_dist, max_dist)
+                    min_dist
                 } else {
                     // The parent is a leaf if the tree is a single node (ie there is only one shape in the tree).
-                    (*best_min_distance, *best_max_distance)
+                    *best_min_distance
                 };
 
                 // we reached a leaf, we add it to the list of indices since it is a potential candidate
-                indices.push((shape_index, min_dist, max_dist));
+                indices.push((shape_index, min_dist));
             }
         }
     }

--- a/mesh_to_sdf/src/bvh_ext.rs
+++ b/mesh_to_sdf/src/bvh_ext.rs
@@ -1,0 +1,191 @@
+use bvh::aabb::Aabb;
+use bvh::bvh::{Bvh, BvhNode};
+use nalgebra::SimdPartialOrd;
+
+use crate::Point;
+
+/// Returns the signed distance to a box.
+/// See <https://iquilezles.org/articles/distfunctions/>
+fn box_sdf<V: Point>(p: &V, aabb: &Aabb<f32, 3>) -> f32 {
+    let p = nalgebra::Point3::new(p.x(), p.y(), p.z());
+    let p = p - aabb.center();
+    let q = p.abs() - aabb.size() * 0.5;
+
+    // lhs is the outside part of the box
+    let lhs = q.simd_max(nalgebra::Vector3::zeros());
+    // rhs is the inside part of the box
+    let rhs = q.max().min(0.0);
+    (lhs + nalgebra::Vector3::from_element(rhs)).norm()
+}
+
+pub trait AabbExt {
+    fn point_distance<V: Point>(&self, point: &V) -> f32;
+    fn body_diagonal(&self) -> f32;
+}
+
+impl AabbExt for Aabb<f32, 3> {
+    /// Returns the signed distance to the aabb.
+    /// See <https://iquilezles.org/articles/distfunctions/>
+    fn point_distance<V: Point>(&self, point: &V) -> f32 {
+        let p = nalgebra::Point3::new(point.x(), point.y(), point.z());
+        let p = p - self.center();
+        let q = p.abs() - self.size() * 0.5;
+
+        // lhs is the outside part of the box
+        let lhs = nalgebra::Vector3::new(q.x.max(0.0), q.y.max(0.0), q.z.max(0.0));
+        // rhs is the inside part of the box
+        let rhs = q.max().min(0.0);
+        (lhs + nalgebra::Vector3::from_element(rhs)).norm()
+    }
+
+    /// Returns the body diagonal of the aabb.
+    fn body_diagonal(&self) -> f32 {
+        self.size().norm()
+    }
+}
+
+pub trait BvhDistance<V: Point> {
+    fn traverse_distance(&self, origin: &V) -> Vec<usize>
+    where
+        Self: std::marker::Sized;
+}
+
+impl<V: Point> BvhDistance<V> for Bvh<f32, 3> {
+    fn traverse_distance(&self, origin: &V) -> Vec<usize> {
+        let mut indices = Vec::new();
+        let mut best_min_distance = f32::MAX;
+        let mut best_max_distance = f32::MAX;
+        BvhNode::traverse_recursive_distance(
+            &self.nodes,
+            0,
+            origin,
+            &mut indices,
+            &mut best_min_distance,
+            &mut best_max_distance,
+        );
+
+        indices
+            .into_iter()
+            .filter(|(_, node_min, _)| *node_min <= best_max_distance)
+            .map(|(i, _, _)| i)
+            .collect()
+    }
+}
+pub trait BvhTraverseDistance<V: Point> {
+    fn traverse_recursive_distance(
+        nodes: &[Self],
+        node_index: usize,
+        origin: &V,
+        indices: &mut Vec<(usize, f32, f32)>,
+        best_min_distance: &mut f32,
+        best_max_distance: &mut f32,
+    ) where
+        Self: std::marker::Sized;
+}
+
+impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
+    fn traverse_recursive_distance(
+        nodes: &[Self],
+        node_index: usize,
+        origin: &V,
+        indices: &mut Vec<(usize, f32, f32)>,
+        best_min_distance: &mut f32,
+        best_max_distance: &mut f32,
+    ) {
+        match nodes[node_index] {
+            BvhNode::Node {
+                ref child_l_aabb,
+                child_l_index,
+                ref child_r_aabb,
+                child_r_index,
+                ..
+            } => {
+                let l_dist = child_l_aabb.point_distance(origin);
+                let r_dist = child_r_aabb.point_distance(origin);
+
+                let l_min_dist = l_dist.max(0.0);
+                let r_min_dist = r_dist.max(0.0);
+
+                // if l_dist is positive, we add the dist to aabb to the body diagonal
+                // if it is negative, we still add it and it will be a subtraction since it is negative.
+                // in both cases it keeps the triangle inequality.
+                let l_max_dist = l_dist + child_l_aabb.body_diagonal();
+                let r_max_dist = r_dist + child_r_aabb.body_diagonal();
+
+                if !indices.is_empty() && l_max_dist < *best_min_distance {
+                    // left node is better by a margin
+                    indices.clear();
+                }
+
+                if !indices.is_empty() && r_max_dist < *best_min_distance {
+                    // right node is better by a margin
+                    indices.clear();
+                }
+
+                *best_max_distance = best_max_distance.min(l_max_dist.min(r_max_dist));
+
+                if l_min_dist <= *best_max_distance {
+                    Self::traverse_recursive_distance(
+                        nodes,
+                        child_l_index,
+                        origin,
+                        indices,
+                        best_min_distance,
+                        best_max_distance,
+                    );
+                }
+
+                if r_min_dist <= *best_max_distance {
+                    Self::traverse_recursive_distance(
+                        nodes,
+                        child_r_index,
+                        origin,
+                        indices,
+                        best_min_distance,
+                        best_max_distance,
+                    );
+                }
+            }
+            BvhNode::Leaf {
+                shape_index,
+                parent_index,
+            } => {
+                let parent_node = &nodes[parent_index];
+                if let BvhNode::Node {
+                    ref child_l_aabb,
+                    child_l_index,
+                    ref child_r_aabb,
+                    child_r_index,
+                    ..
+                } = parent_node
+                {
+                    let mut min_dist = f32::MAX;
+                    let mut max_dist = f32::MAX;
+                    if *child_l_index == node_index {
+                        let l_dist = child_l_aabb.point_distance(origin);
+                        min_dist = l_dist.max(0.0);
+                        max_dist = l_dist + child_l_aabb.body_diagonal();
+                    }
+                    if *child_r_index == node_index {
+                        let r_dist = child_r_aabb.point_distance(origin);
+                        min_dist = r_dist.max(0.0);
+                        max_dist = r_dist + child_r_aabb.body_diagonal();
+                    }
+
+                    if !indices.is_empty() && max_dist < *best_min_distance {
+                        // left node is better by a margin
+                        indices.clear();
+                    }
+                    *best_min_distance = best_min_distance.min(min_dist);
+                    *best_max_distance = best_max_distance.min(max_dist);
+
+                    // we reached a leaf, we add it to the list of indices since it is a potential candidate
+                    indices.push((shape_index, min_dist, max_dist));
+                } else {
+                    // The parent is a leaf if the tree is a single node (ie there is only one shape in the tree).
+                    indices.push((shape_index, *best_min_distance, *best_max_distance));
+                }
+            }
+        }
+    }
+}

--- a/mesh_to_sdf/src/bvh_ext.rs
+++ b/mesh_to_sdf/src/bvh_ext.rs
@@ -19,43 +19,64 @@ fn box_sdf<V: Point>(p: &V, aabb: &Aabb<f32, 3>) -> f32 {
 }
 
 pub trait AabbExt {
-    fn point_distance<V: Point>(&self, point: &V) -> f32;
-    fn body_diagonal(&self) -> f32;
+    /// Returns the minimum and maximum distances to the box.
+    /// The minimum distance is the distance to the closest point on the box,
+    /// 0 if the point is inside the box.
+    /// The maximum distance is the distance to the furthest point in the box.
+    fn get_min_max_distances<V: Point>(&self, point: &V) -> (f32, f32);
 }
 
 impl AabbExt for Aabb<f32, 3> {
-    /// Returns the signed distance to the aabb.
-    /// See <https://iquilezles.org/articles/distfunctions/>
-    fn point_distance<V: Point>(&self, point: &V) -> f32 {
-        let p = nalgebra::Point3::new(point.x(), point.y(), point.z());
-        let p = p - self.center();
-        let q = p.abs() - self.size() * 0.5;
+    /// Returns the minimum and maximum distances to the box.
+    /// The minimum distance is the distance to the closest point on the box,
+    /// 0 if the point is inside the box.
+    /// The maximum distance is the distance to the furthest point in the box.
+    fn get_min_max_distances<V: Point>(&self, point: &V) -> (f32, f32) {
+        // Convert point to nalgebra point
+        let n_point: nalgebra::OPoint<f32, nalgebra::Const<3>> =
+            nalgebra::Point3::new(point.x(), point.y(), point.z());
 
-        // lhs is the outside part of the box
-        let lhs = nalgebra::Vector3::new(q.x.max(0.0), q.y.max(0.0), q.z.max(0.0));
-        // rhs is the inside part of the box
-        let rhs = q.max().min(0.0);
-        (lhs + nalgebra::Vector3::from_element(rhs)).norm()
-    }
+        let half_size = self.size() * 0.5;
+        let center = self.center();
 
-    /// Returns the body diagonal of the aabb.
-    fn body_diagonal(&self) -> f32 {
-        self.size().norm()
+        let delta = n_point - center;
+
+        // See <https://iquilezles.org/articles/distfunctions/>
+        let q = delta.abs() - half_size;
+        let min_dist = q.map(|x| x.max(0.0)).norm();
+
+        // The signum helps to determine the furthest point
+        let signum = delta
+            // Invert the signum to get the furthest vertex
+            .map(|x| -x.signum())
+            // Make sure we're always on a vertex and not on a face if the point is aligned with the box
+            .map(|x| if x != 0.0 { x } else { 1.0 });
+
+        let furthest = center + signum.component_mul(&half_size);
+        let max_dist = (n_point - furthest).norm();
+
+        (min_dist, max_dist)
     }
 }
 
 pub trait BvhDistance<V: Point> {
-    fn traverse_distance(&self, origin: &V) -> Vec<usize>
+    /// Traverses the [`Bvh`].
+    /// Returns a subset of `shapes` which are candidates for being the closest to `point`.
+    ///
+    fn nearest_candidates(&self, origin: &V) -> Vec<usize>
     where
         Self: std::marker::Sized;
 }
 
 impl<V: Point> BvhDistance<V> for Bvh<f32, 3> {
-    fn traverse_distance(&self, origin: &V) -> Vec<usize> {
+    /// Traverses the [`Bvh`].
+    /// Returns a subset of `shapes` which are candidates for being the closest to `point`.
+    ///
+    fn nearest_candidates(&self, origin: &V) -> Vec<usize> {
         let mut indices = Vec::new();
         let mut best_min_distance = f32::MAX;
         let mut best_max_distance = f32::MAX;
-        BvhNode::traverse_recursive_distance(
+        BvhNode::nearest_candidates_recursive(
             &self.nodes,
             0,
             origin,
@@ -72,7 +93,10 @@ impl<V: Point> BvhDistance<V> for Bvh<f32, 3> {
     }
 }
 pub trait BvhTraverseDistance<V: Point> {
-    fn traverse_recursive_distance(
+    /// Traverses the [`Bvh`] recursively and returns all shapes whose [`Aabb`] countains
+    /// a candidate shape for being the nearest to the given point.
+    ///
+    fn nearest_candidates_recursive(
         nodes: &[Self],
         node_index: usize,
         origin: &V,
@@ -84,7 +108,10 @@ pub trait BvhTraverseDistance<V: Point> {
 }
 
 impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
-    fn traverse_recursive_distance(
+    /// Traverses the [`Bvh`] recursively and returns all shapes whose [`Aabb`] countains
+    /// a candidate shape for being the nearest to the given point.
+    ///
+    fn nearest_candidates_recursive(
         nodes: &[Self],
         node_index: usize,
         origin: &V,
@@ -100,91 +127,75 @@ impl<V: Point> BvhTraverseDistance<V> for BvhNode<f32, 3> {
                 child_r_index,
                 ..
             } => {
-                let l_dist = child_l_aabb.point_distance(origin);
-                let r_dist = child_r_aabb.point_distance(origin);
+                // Compute min/max dists for both children
+                let [child_l_dists, child_r_dists] =
+                    [child_l_aabb, child_r_aabb].map(|aabb| aabb.get_min_max_distances(origin));
 
-                let l_min_dist = l_dist.max(0.0);
-                let r_min_dist = r_dist.max(0.0);
+                // Update best max distance before traversing children to avoid unnecessary traversals
+                // where right node prunes left node.
+                *best_max_distance = best_max_distance.min(child_l_dists.1.min(child_r_dists.1));
 
-                // if l_dist is positive, we add the dist to aabb to the body diagonal
-                // if it is negative, we still add it and it will be a subtraction since it is negative.
-                // in both cases it keeps the triangle inequality.
-                let l_max_dist = l_dist + child_l_aabb.body_diagonal();
-                let r_max_dist = r_dist + child_r_aabb.body_diagonal();
+                // Traverse children
+                for ((dist_min, dist_max), index) in [
+                    (child_l_dists, child_l_index),
+                    (child_r_dists, child_r_index),
+                ] {
+                    // Node is better by a margin.
+                    if dist_max <= *best_min_distance {
+                        indices.clear();
+                    }
 
-                if !indices.is_empty() && l_max_dist < *best_min_distance {
-                    // left node is better by a margin
-                    indices.clear();
-                }
-
-                if !indices.is_empty() && r_max_dist < *best_min_distance {
-                    // right node is better by a margin
-                    indices.clear();
-                }
-
-                *best_max_distance = best_max_distance.min(l_max_dist.min(r_max_dist));
-
-                if l_min_dist <= *best_max_distance {
-                    Self::traverse_recursive_distance(
-                        nodes,
-                        child_l_index,
-                        origin,
-                        indices,
-                        best_min_distance,
-                        best_max_distance,
-                    );
-                }
-
-                if r_min_dist <= *best_max_distance {
-                    Self::traverse_recursive_distance(
-                        nodes,
-                        child_r_index,
-                        origin,
-                        indices,
-                        best_min_distance,
-                        best_max_distance,
-                    );
+                    // Node might contain a candidate
+                    if dist_min <= *best_max_distance {
+                        Self::nearest_candidates_recursive(
+                            nodes,
+                            index,
+                            origin,
+                            indices,
+                            best_min_distance,
+                            best_max_distance,
+                        );
+                    }
                 }
             }
             BvhNode::Leaf {
                 shape_index,
                 parent_index,
             } => {
+                // Try to compute bounding box via parent node to update best_min/max_distances
                 let parent_node = &nodes[parent_index];
-                if let BvhNode::Node {
+                let (min_dist, max_dist) = if let BvhNode::Node {
                     ref child_l_aabb,
                     child_l_index,
                     ref child_r_aabb,
-                    child_r_index,
                     ..
                 } = parent_node
                 {
-                    let mut min_dist = f32::MAX;
-                    let mut max_dist = f32::MAX;
-                    if *child_l_index == node_index {
-                        let l_dist = child_l_aabb.point_distance(origin);
-                        min_dist = l_dist.max(0.0);
-                        max_dist = l_dist + child_l_aabb.body_diagonal();
-                    }
-                    if *child_r_index == node_index {
-                        let r_dist = child_r_aabb.point_distance(origin);
-                        min_dist = r_dist.max(0.0);
-                        max_dist = r_dist + child_r_aabb.body_diagonal();
-                    }
+                    // We found a parent node, we can compute the min/max distances for the leaf shape.
+                    let aabb = if *child_l_index == node_index {
+                        child_l_aabb
+                    } else {
+                        child_r_aabb
+                    };
+                    let (min_dist, max_dist) = aabb.get_min_max_distances(origin);
 
                     if !indices.is_empty() && max_dist < *best_min_distance {
-                        // left node is better by a margin
+                        // Node is better by a margin
                         indices.clear();
                     }
+
+                    // Also update min_dist here since we have a credible (small) bounding box.
                     *best_min_distance = best_min_distance.min(min_dist);
                     *best_max_distance = best_max_distance.min(max_dist);
 
-                    // we reached a leaf, we add it to the list of indices since it is a potential candidate
-                    indices.push((shape_index, min_dist, max_dist));
+                    (min_dist, max_dist)
                 } else {
                     // The parent is a leaf if the tree is a single node (ie there is only one shape in the tree).
-                    indices.push((shape_index, *best_min_distance, *best_max_distance));
-                }
+                    (*best_min_distance, *best_max_distance)
+                };
+
+                // we reached a leaf, we add it to the list of indices since it is a potential candidate
+                indices.push((shape_index, min_dist, max_dist));
             }
         }
     }

--- a/mesh_to_sdf/src/bvh_ext.rs
+++ b/mesh_to_sdf/src/bvh_ext.rs
@@ -92,6 +92,7 @@ impl<V: Point> BvhDistance<V> for Bvh<f32, 3> {
             .collect()
     }
 }
+
 pub trait BvhTraverseDistance<V: Point> {
     /// Traverses the [`Bvh`] recursively and returns all shapes whose [`Aabb`] countains
     /// a candidate shape for being the nearest to the given point.

--- a/mesh_to_sdf/src/geo.rs
+++ b/mesh_to_sdf/src/geo.rs
@@ -138,6 +138,7 @@ fn closest_point_segment<V: Point>(p: &V, a: &V, b: &V) -> V {
 
 /// Grid alignment for raycast.
 /// Used exclusively in `ray_triangle_intersection_aligned`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GridAlign {
     X,
     Y,

--- a/mesh_to_sdf/src/lib.rs
+++ b/mesh_to_sdf/src/lib.rs
@@ -348,7 +348,7 @@ where
     query_points
         .par_iter()
         .map(|point| {
-            let bvh_indices = bvh.traverse_distance(point);
+            let bvh_indices = bvh.nearest_candidates(point);
 
             let mut min_dist = f32::MAX;
             if sign_method == SignMethod::Normal {
@@ -1077,6 +1077,8 @@ mod tests {
             cgmath::Vector3::new(0.01, 0.01, 0.5),
             cgmath::Vector3::new(1.0, 1.0, 1.0),
             cgmath::Vector3::new(0.1, 0.2, 0.2),
+            cgmath::Vector3::new(1.1, 2.2, 5.2),
+            cgmath::Vector3::new(-0.1, 0.2, -0.2),
         ];
 
         let bvh_sdf = generate_sdf(
@@ -1095,8 +1097,14 @@ mod tests {
             SignMethod::Raycast,
         );
 
-        for (bvh, sdf) in bvh_sdf.iter().zip(sdf.iter()) {
-            assert!((bvh - sdf).abs() < 0.1, "{} !+ {}", bvh, sdf);
+        for (idx, (bvh, sdf)) in bvh_sdf.iter().zip(sdf.iter()).enumerate() {
+            assert!(
+                (bvh - sdf).abs() < 0.1,
+                "{:?}: {} != {}",
+                query_points[idx],
+                bvh,
+                sdf
+            );
         }
     }
 }

--- a/mesh_to_sdf/src/lib.rs
+++ b/mesh_to_sdf/src/lib.rs
@@ -348,7 +348,7 @@ where
     query_points
         .par_iter()
         .map(|point| {
-            let bvh_indices = bvh.nearest_candidates(point);
+            let bvh_indices = bvh.nearest_candidates(point, &bvh_nodes);
 
             let mut min_dist = f32::MAX;
             if sign_method == SignMethod::Normal {

--- a/mesh_to_sdf/src/point.rs
+++ b/mesh_to_sdf/src/point.rs
@@ -9,7 +9,7 @@ mod impl_cgmath;
 mod impl_glam;
 #[cfg(feature = "mint")]
 mod impl_mint;
-#[cfg(feature = "nalgebra")]
+//#[cfg(feature = "nalgebra")]
 mod impl_nalgebra;
 
 /// Point is the trait that represents a point in 3D space.

--- a/mesh_to_sdf/src/serde.rs
+++ b/mesh_to_sdf/src/serde.rs
@@ -182,7 +182,7 @@ pub fn save_to_file<V: Point + Serialize + DeserializeOwned, P: AsRef<Path>>(
 pub fn read_from_file<V: Point + Serialize + DeserializeOwned, P: AsRef<Path>>(
     path: P,
 ) -> Result<DeserializeSdf<V>, SerdeError> {
-    Ok(deserialize(&std::fs::read(path)?)?)
+    deserialize(&std::fs::read(path)?)
 }
 
 // ----------------------------------------------------------------------------

--- a/mesh_to_sdf_client/CHANGELOG.md
+++ b/mesh_to_sdf_client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Voxel and Raymarch visualizations now map the material of the mesh onto the new geometry.
 
 ## [0.2.1] - 2024-02-18
 


### PR DESCRIPTION

`generate_sdf` now takes a `AccelerationMethod` parameter, that can be either `AccelerationMethod::Bvh` (default) or `AccelerationMethod::None`.
 
`Bvh` is recommended unless you're really tight on memory or your query is very small (couple hundreds of queries and triangles).

For example, a query of 15k points with 100k triangles is 10 times faster with a bvh, and twice faster for 500 queries and 10k triangles.

`Bvh` is also optimised for the `SignMethod::Raycast` sign method.
